### PR TITLE
fix: prevent image distortion during cropping

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1776,6 +1776,7 @@ export default function OverlayPage() {
                             images={images}
                             setImages={setImages}
                             isDraggingImage={isDraggingImage}
+                            isCroppingImage={croppingImageId == image.id}
                             dragStartPositions={dragStartPositions}
                           />
                         ))}

--- a/src/components/canvas/CanvasImage.tsx
+++ b/src/components/canvas/CanvasImage.tsx
@@ -17,6 +17,7 @@ interface CanvasImageProps {
   images: PlacedImage[];
   setImages: React.Dispatch<React.SetStateAction<PlacedImage[]>>;
   isDraggingImage: boolean;
+  isCroppingImage: boolean;
   dragStartPositions: Map<string, { x: number; y: number }>;
 }
 
@@ -32,6 +33,7 @@ export const CanvasImage: React.FC<CanvasImageProps> = ({
   images,
   setImages,
   isDraggingImage,
+  isCroppingImage,
   dragStartPositions,
 }) => {
   const shapeRef = useRef<Konva.Image>(null);
@@ -66,7 +68,7 @@ export const CanvasImage: React.FC<CanvasImageProps> = ({
         height={image.height}
         rotation={image.rotation}
         crop={
-          image.cropX !== undefined
+          image.cropX !== undefined && !isCroppingImage
             ? {
                 x: (image.cropX || 0) * (img?.naturalWidth || 0),
                 y: (image.cropY || 0) * (img?.naturalHeight || 0),


### PR DESCRIPTION
YO! Fixes #1 

## What changed
- Only apply crop transformations when the image is not currently being cropped

| Before (Issue) | After (Fixed) |
|----------------|---------------|
| ![2025-07-1620-55-41-ezgif com-optimize](https://github.com/user-attachments/assets/973c3a10-e8c9-472a-9853-9d8c4b0f3a9c) | ![2025-07-1621-01-29-ezgif com-optimize](https://github.com/user-attachments/assets/0f552c8c-715c-4658-b135-e359f548982a) |
