### PR TITLE
Feat: add layer ordering with send to front/back controls with shortcuts

### DIFF
--- a/src/components/canvas/CanvasContextMenu.tsx
+++ b/src/components/canvas/CanvasContextMenu.tsx
@@ -19,6 +19,11 @@ import {
   Combine,
   Download,
   X,
+  Layers,
+  ChevronUp,
+  ChevronDown,
+  MoveUp,
+  MoveDown,
 } from "lucide-react";
 import { SpinnerIcon } from "@/components/icons";
 import { checkOS } from "@/utils/os-utils";
@@ -40,6 +45,10 @@ interface CanvasContextMenuProps {
   setCroppingImageId: (id: string | null) => void;
   setIsolateInputValue: (value: string) => void;
   setIsolateTarget: (id: string | null) => void;
+  sendToFront: () => void;
+  sendToBack: () => void;
+  bringForward: () => void;
+  sendBackward: () => void;
 }
 
 export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
@@ -58,6 +67,10 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
   setCroppingImageId,
   setIsolateInputValue,
   setIsolateTarget,
+  sendToFront,
+  sendToBack,
+  bringForward,
+  sendBackward,
 }) => {
   return (
     <ContextMenuContent>
@@ -78,9 +91,7 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
           variant="alpha"
           size="xs"
           shortcut={
-            checkOS("Win") || checkOS("Linux")
-              ? "ctrl+enter"
-              : "meta+enter"
+            checkOS("Win") || checkOS("Linux") ? "ctrl+enter" : "meta+enter"
           }
         />
       </ContextMenuItem>
@@ -202,6 +213,73 @@ export const CanvasContextMenu: React.FC<CanvasContextMenuProps> = ({
         <Combine className="h-4 w-4" />
         Combine Images
       </ContextMenuItem>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger
+          disabled={selectedIds.length === 0}
+          className="flex items-center gap-2"
+        >
+          <Layers className="h-4 w-4" />
+          Layer Order
+        </ContextMenuSubTrigger>
+        <ContextMenuSubContent className="w-64" sideOffset={5}>
+          <ContextMenuItem
+            onClick={sendToFront}
+            disabled={selectedIds.length === 0}
+            className="flex items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <MoveUp className="h-4 w-4" />
+              <span>Send to Front</span>
+            </div>
+            <ShortcutBadge
+              variant="alpha"
+              size="xs"
+              shortcut={
+                checkOS("Win") || checkOS("Linux") ? "ctrl+]" : "meta+]"
+              }
+            />
+          </ContextMenuItem>
+          <ContextMenuItem
+            onClick={bringForward}
+            disabled={selectedIds.length === 0}
+            className="flex items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <ChevronUp className="h-4 w-4" />
+              <span>Bring Forward</span>
+            </div>
+            <ShortcutBadge variant="alpha" size="xs" shortcut="]" />
+          </ContextMenuItem>
+          <ContextMenuItem
+            onClick={sendBackward}
+            disabled={selectedIds.length === 0}
+            className="flex items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <ChevronDown className="h-4 w-4" />
+              <span>Send Backward</span>
+            </div>
+            <ShortcutBadge variant="alpha" size="xs" shortcut="[" />
+          </ContextMenuItem>
+          <ContextMenuItem
+            onClick={sendToBack}
+            disabled={selectedIds.length === 0}
+            className="flex items-center justify-between gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <MoveDown className="h-4 w-4" />
+              <span>Send to Back</span>
+            </div>
+            <ShortcutBadge
+              variant="alpha"
+              size="xs"
+              shortcut={
+                checkOS("Win") || checkOS("Linux") ? "ctrl+[" : "meta+["
+              }
+            />
+          </ContextMenuItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
       <ContextMenuItem
         onClick={() => {
           selectedIds.forEach((id) => {

--- a/src/components/canvas/MobileToolbar.tsx
+++ b/src/components/canvas/MobileToolbar.tsx
@@ -2,6 +2,12 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Play,
   Copy,
   Crop,
@@ -9,6 +15,11 @@ import {
   Combine,
   Download,
   Trash2,
+  Layers,
+  ChevronUp,
+  ChevronDown,
+  MoveUp,
+  MoveDown,
 } from "lucide-react";
 import { SpinnerIcon } from "@/components/icons";
 import type { PlacedImage, GenerationSettings } from "@/types/canvas";
@@ -24,6 +35,10 @@ interface MobileToolbarProps {
   handleCombineImages: () => void;
   handleDelete: () => void;
   setCroppingImageId: (id: string | null) => void;
+  sendToFront: () => void;
+  sendToBack: () => void;
+  bringForward: () => void;
+  sendBackward: () => void;
 }
 
 export const MobileToolbar: React.FC<MobileToolbarProps> = ({
@@ -37,6 +52,10 @@ export const MobileToolbar: React.FC<MobileToolbarProps> = ({
   handleCombineImages,
   handleDelete,
   setCroppingImageId,
+  sendToFront,
+  sendToBack,
+  bringForward,
+  sendBackward,
 }) => {
   return (
     <div
@@ -110,6 +129,76 @@ export const MobileToolbar: React.FC<MobileToolbarProps> = ({
       >
         <Combine className="h-12 w-12" />
       </Button>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={selectedIds.length === 0}
+            className="w-12 h-12 p-0"
+            title="Layer Order"
+          >
+            <Layers className="h-12 w-12" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          side="right"
+          sideOffset={10}
+          alignOffset={-4}
+          align="start"
+          className="w-48 space-y-1 bg-background/80 border rounded p-1"
+        >
+          <DropdownMenuItem asChild>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={sendToFront}
+              disabled={selectedIds.length === 0}
+              className="w-full h-12 justify-start gap-3 px-3"
+            >
+              <MoveUp className="h-6 w-6" />
+              <span className="font-medium">Send to Front</span>
+            </Button>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={bringForward}
+              disabled={selectedIds.length === 0}
+              className="w-full h-12 justify-start gap-3 px-3"
+            >
+              <ChevronUp className="h-6 w-6" />
+              <span className="font-medium">Bring Forward</span>
+            </Button>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={sendBackward}
+              disabled={selectedIds.length === 0}
+              className="w-full h-12 justify-start gap-3 px-3"
+            >
+              <ChevronDown className="h-6 w-6" />
+              <span className="font-medium">Send Backward</span>
+            </Button>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={sendToBack}
+              disabled={selectedIds.length === 0}
+              className="w-full h-12 justify-start gap-3 px-3"
+            >
+              <MoveDown className="h-6 w-6" />
+              <span className="font-medium">Send to Back</span>
+            </Button>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <Button
         variant="secondary"


### PR DESCRIPTION
Adds layer ordering functionality with send to front/back controls. Implements #7 

## Features
- Send to Front/Back and Bring Forward/Backward
- Keyboard shortcuts: `]` / `Ctrl+]` and `[` / `Ctrl+[`
- Desktop: Context menu submenu
- Mobile: Dropdown from Layers button
- History integration for undo/redo

Uses array-based layering where array index = z-order.

<table>
<tr>
<td>
<b>Mobile</b><br>
<img src="https://github.com/user-attachments/assets/82229f61-c726-42b0-93d9-6229a2b7884c">
</td>
</tr>
<tr>
<td>
<b>Desktop</b><br>
<img src="https://github.com/user-attachments/assets/04874d4c-0657-4b0c-bdd3-ce162529ee40">
</td>
</tr>
</table>
