### PR TITLE
Fix: drag rerender bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14330,6 +14330,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
+      "integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
+      "integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
+      "integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
+      "integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
+      "integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
+      "integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
+      "integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1772,10 +1772,10 @@ export default function OverlayPage() {
                     scaleY={viewport.scale}
                     draggable={false}
                     onDragStart={(e) => {
-                      e.evt.preventDefault();
+                      e.evt?.preventDefault();
                     }}
                     onDragEnd={(e) => {
-                      e.evt.preventDefault();
+                      e.evt?.preventDefault();
                     }}
                     onMouseDown={handleMouseDown}
                     onMousemove={handleMouseMove}

--- a/src/components/canvas/CanvasImage.tsx
+++ b/src/components/canvas/CanvasImage.tsx
@@ -182,11 +182,14 @@ export const CanvasImage: React.FC<CanvasImageProps> = ({
               );
             }
           } else {
-            // Single item: update only this image's position
-            onChange({
-              x: node.x(),
-              y: node.y(),
-            });
+            // Single item: update only this image's position in the images array
+            setImages((prev) =>
+              prev.map((img) =>
+                img.id === image.id
+                  ? { ...img, x: node.x(), y: node.y() }
+                  : img
+              )
+            );
           }
 
           onDragEnd();

--- a/src/components/canvas/CanvasImage.tsx
+++ b/src/components/canvas/CanvasImage.tsx
@@ -187,8 +187,8 @@ export const CanvasImage: React.FC<CanvasImageProps> = ({
               prev.map((img) =>
                 img.id === image.id
                   ? { ...img, x: node.x(), y: node.y() }
-                  : img
-              )
+                  : img,
+              ),
             );
           }
 

--- a/test-precommit.js
+++ b/test-precommit.js
@@ -1,2 +1,0 @@
-// Test file to verify pre-commit hook
-console.log("Testing pre-commit hook");

--- a/test-precommit.js
+++ b/test-precommit.js
@@ -1,0 +1,2 @@
+// Test file to verify pre-commit hook
+console.log("Testing pre-commit hook");


### PR DESCRIPTION
Fixes #21 by updating image state only on drag end, not during drag. Removes unnecessary state updates in onDragMove, letting Konva handle visuals. Prevents re-renders when dragging images off-canvas and keeps multi-select working.