### PR TITLE
fixed crop button scaling issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "lint-staged": "^15.5.0",
         "node-fetch": "^3.3.2",
         "postcss": "^8",
-        "prettier": "^3.5.3",
+        "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1922,6 +1922,7 @@ export default function OverlayPage() {
                           return (
                             <CropOverlayWrapper
                               image={croppingImage}
+                              viewportScale={viewport.scale}
                               onCropChange={(crop) => {
                                 setImages((prev) =>
                                   prev.map((img) =>

--- a/src/components/canvas/CropOverlay.tsx
+++ b/src/components/canvas/CropOverlay.tsx
@@ -20,6 +20,7 @@ interface CropOverlayProps {
     cropHeight: number;
   }) => void;
   onCropEnd: () => void;
+  viewportScale?: number;
 }
 
 export const CropOverlay: React.FC<CropOverlayProps> = ({
@@ -27,6 +28,7 @@ export const CropOverlay: React.FC<CropOverlayProps> = ({
   imageElement,
   onCropChange,
   onCropEnd,
+  viewportScale = 1,
 }) => {
   const cropRectRef = useRef<Konva.Rect>(null);
   const cropTransformerRef = useRef<Konva.Transformer>(null);
@@ -223,8 +225,10 @@ export const CropOverlay: React.FC<CropOverlayProps> = ({
 
       {/* Done button - styled to match our button component */}
       <Group
-        x={cropX + cropWidth - 70}
-        y={cropY - 45}
+        x={cropX + cropWidth - 70 / viewportScale}
+        y={cropY - 45 / viewportScale}
+        scaleX={1 / viewportScale}
+        scaleY={1 / viewportScale}
         onMouseEnter={() => setIsHoveringDone(true)}
         onMouseLeave={() => setIsHoveringDone(false)}
         onClick={onCropEnd}

--- a/src/components/canvas/CropOverlayWrapper.tsx
+++ b/src/components/canvas/CropOverlayWrapper.tsx
@@ -12,12 +12,14 @@ interface CropOverlayWrapperProps {
     cropHeight: number;
   }) => void;
   onCropEnd: () => void;
+  viewportScale?: number;
 }
 
 export const CropOverlayWrapper: React.FC<CropOverlayWrapperProps> = ({
   image,
   onCropChange,
   onCropEnd,
+  viewportScale = 1,
 }) => {
   const [img] = useImage(image.src, "anonymous");
 
@@ -29,6 +31,7 @@ export const CropOverlayWrapper: React.FC<CropOverlayWrapperProps> = ({
       imageElement={img}
       onCropChange={onCropChange}
       onCropEnd={onCropEnd}
+      viewportScale={viewportScale}
     />
   );
 };


### PR DESCRIPTION
Fixes crop button scaling so the Done button stays the same size regardless of canvas zoom. Adds viewportScale prop and applies inverse scaling to keep the button easily clickable at all zoom levels.

fixes #4 (previously fixed UI with #25 )