### PR TITLE
feat: turn crop done button into html with portals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "react-image-crop": "^11.0.5",
         "react-intersection-observer": "^9.16.0",
         "react-konva": "^19.0.7",
+        "react-konva-utils": "^1.1.1",
         "react-markdown": "^10.1.0",
         "react-rnd": "^10.5.2",
         "react-syntax-highlighter": "^15.6.1",
@@ -11705,6 +11706,20 @@
         "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
         "react": "^18.3.1 || ^19.0.0",
         "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/react-konva-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-konva-utils/-/react-konva-utils-1.1.1.tgz",
+      "integrity": "sha512-3GB3UmXjrOJpWRT3TXRFjRpGs9cBWSRqfWaKmvp2Ry5gF6LY9VziN49L6frOQ1h79ynpzsUwPfepefYm1dmyWw==",
+      "dependencies": {
+        "use-image": "^1.1.1"
+      },
+      "peerDependencies": {
+        "konva": "^8.3.5 || ^9.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0",
+        "react-konva": "^18.2.10 || ^19.0.1"
       }
     },
     "node_modules/react-markdown": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "react-image-crop": "^11.0.5",
     "react-intersection-observer": "^9.16.0",
     "react-konva": "^19.0.7",
+    "react-konva-utils": "^1.1.1",
     "react-markdown": "^10.1.0",
     "react-rnd": "^10.5.2",
     "react-syntax-highlighter": "^15.6.1",

--- a/src/components/canvas/CropOverlay.tsx
+++ b/src/components/canvas/CropOverlay.tsx
@@ -2,13 +2,14 @@ import React, { useRef, useState, useEffect } from "react";
 import {
   Rect,
   Group,
-  Text,
   Line,
   Image as KonvaImage,
   Transformer,
 } from "react-konva";
+import { Html } from "react-konva-utils";
 import Konva from "konva";
 import type { PlacedImage } from "@/types/canvas";
+import { Button } from "@/components/ui/button";
 
 interface CropOverlayProps {
   image: PlacedImage;
@@ -33,7 +34,6 @@ export const CropOverlay: React.FC<CropOverlayProps> = ({
   const cropRectRef = useRef<Konva.Rect>(null);
   const cropTransformerRef = useRef<Konva.Transformer>(null);
   const [grid, setGrid] = useState<Array<{ points: number[] }>>([]);
-  const [isHoveringDone, setIsHoveringDone] = useState(false);
 
   // Initialize crop values (default to full image if not set)
   const cropX = (image.cropX ?? 0) * image.width;
@@ -223,40 +223,21 @@ export const CropOverlay: React.FC<CropOverlayProps> = ({
         flipEnabled={false}
       />
 
-      {/* Done button - styled to match our button component */}
-      <Group
-        x={cropX + cropWidth - 70 / viewportScale}
-        y={cropY - 45 / viewportScale}
-        scaleX={1 / viewportScale}
-        scaleY={1 / viewportScale}
-        onMouseEnter={() => setIsHoveringDone(true)}
-        onMouseLeave={() => setIsHoveringDone(false)}
-        onClick={onCropEnd}
-        onTap={onCropEnd}
+      {/* Done button - HTML rendered using portal */}
+      <Html
+        groupProps={{
+          x: cropX + cropWidth,
+          y: cropY,
+          scaleX: 1 / viewportScale,
+          scaleY: 1 / viewportScale,
+        }}
       >
-        <Rect
-          width={70}
-          height={36}
-          fill={isHoveringDone ? "#8b5cf6" : "#a855f7"}
-          cornerRadius={6}
-          shadowColor="black"
-          shadowBlur={8}
-          shadowOpacity={0.15}
-          shadowOffsetY={2}
-        />
-        <Text
-          text="Done"
-          fontSize={14}
-          fontFamily="system-ui, -apple-system, sans-serif"
-          fontStyle="500"
-          fill="white"
-          width={70}
-          height={36}
-          align="center"
-          verticalAlign="middle"
-          listening={false}
-        />
-      </Group>
+        <div className="py-2 -translate-x-full -translate-y-full">
+          <Button variant="primary" onClick={onCropEnd} className="select-none">
+            Done
+          </Button>
+        </div>
+      </Html>
     </Group>
   );
 };


### PR DESCRIPTION
Moved the crop mode "Done" button from canvas rendering to HTML using `react-konva-utils` Html component. Now uses shadcn Button with primary variant.

Discovered Konva's DOM portal feature from the [official docs](https://konvajs.org/docs/react/DOM_Portal.html)

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/06bada88-d30c-48e0-aeba-89cad94f6f54" width="100%"></td>
    <td><img src="https://github.com/user-attachments/assets/d3f885a3-78e4-44f4-b88c-175a49a54860" width="100%">    </td>
  </tr>
</table>